### PR TITLE
fix deprecated network command

### DIFF
--- a/plugins/net.sh
+++ b/plugins/net.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-LABEL=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk 'NR==13 {print $2}')
+LABEL=$(ipconfig getsummary en0 | awk -F ' SSID : '  '/ SSID : / {print $2}')
 
 sketchybar --set $NAME label=$LABEL


### PR DESCRIPTION
### Description

On macOS Sequoia `(15.0)`, the `airport -I` command is **deprecated** and cannot correctly display Wi-Fi information.




